### PR TITLE
Update deprecated collections Sequence reference

### DIFF
--- a/pypkjs/javascript/pebble.py
+++ b/pypkjs/javascript/pebble.py
@@ -164,7 +164,7 @@ class Pebble(events.EventSourceMixin, v8.JSClass):
                     self.runtime.log_output("WARNING: illegal float value %s for appmessage key %s" % (v, k))
                     intv = 0
                 v = Int32(intv)
-            elif isinstance(v, collections.Sequence):
+            elif isinstance(v, collections.abc.Sequence):
                 b = bytearray()
                 for byte in v:
                     if isinstance(byte, int):


### PR DESCRIPTION
Fixes an issue where sending messages from the phone sim fails with the error message
```
pkjs> ReferenceError: ReferenceError: module 'collections' has no attribute 'Sequence' (  @ 1 : 49 )  -> (function sendAppMessage() { return origin[name].apply(origin, arguments); })
```
