### PR TITLE
fix: support collections.abc.Sequence for later py3 versions

### DIFF
--- a/pypkjs/javascript/pebble.py
+++ b/pypkjs/javascript/pebble.py
@@ -29,6 +29,11 @@ from . import events
 from ..timeline.attributes import TimelineAttributeSet
 from .exceptions import JSRuntimeException
 
+# a little hacky but covers both cases for Sequence
+if not hasattr(collections, 'Sequence'):
+    import collections.abc
+    collections.Sequence = collections.abc.Sequence
+
 logger = logging.getLogger('pypkjs.javascript.pebble')
 
 


### PR DESCRIPTION
If you try to send a byte sequences via PebbleKit JS and you're on a newer version of Python, the call will fail, as `collections.Sequence` has been moved to `collections.abc.Sequence`.

Ref: https://docs.python.org/3/library/collections.abc.html#collections.abc.Sequence